### PR TITLE
Let Azure Pipelines checkout out the repositories

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,51 @@
+resources:
+  repositories:
+  - repository: libplist
+    type: github
+    endpoint: libimobiledevice-win32
+    name: libimobiledevice-win32/libplist
+    ref: msvc/master
+  - repository: libusbmuxd
+    type: github
+    endpoint: libimobiledevice-win32
+    name: libimobiledevice-win32/libusbmuxd
+    ref: msvc/master
+  - repository: libimobiledevice
+    type: github
+    endpoint: libimobiledevice-win32
+    name: libimobiledevice-win32/libimobiledevice
+    ref: msvc/master
+  - repository: libideviceactivation
+    type: github
+    endpoint: libimobiledevice-win32
+    name: libimobiledevice-win32/libideviceactivation
+    ref: msvc/master
+  - repository: ideviceinstaller
+    type: github
+    endpoint: libimobiledevice-win32
+    name: libimobiledevice-win32/ideviceinstaller
+    ref: msvc/master
+  - repository: libirecovery
+    type: github
+    endpoint: libimobiledevice-win32
+    name: libimobiledevice-win32/libirecovery
+    ref: msvc/master
+  - repository: idevicerestore
+    type: github
+    endpoint: libimobiledevice-win32
+    name: libimobiledevice-win32/idevicerestore
+    ref: msvc/master
+  - repository: usbmuxd
+    type: github
+    endpoint: libimobiledevice-win32
+    name: libimobiledevice-win32/usbmuxd
+    ref: master-msvc
+  - repository: ios-webkit-debug-proxy
+    type: github
+    endpoint: libimobiledevice-win32
+    name: libimobiledevice-win32/ios-webkit-debug-proxy
+    ref: msvc/master
+
 jobs:
 - job: windows
   strategy:
@@ -14,9 +62,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   steps:
-  - script: |
-      get-source.cmd
-    displayName: Get libimobiledevice source code
+  - template: get-source.yaml
   - task: Cache@2
     inputs:
       key: 'vcpkg_downloads | $(RID)'
@@ -132,6 +178,7 @@ jobs:
     TARGET: x86_64-apple-darwin
     RID: osx-x64
   steps:
+  - template: get-source.yaml
   - script: |
       brew install autoconf automake libtool pkg-config libzip libusb
     displayName: Install autotools
@@ -172,6 +219,7 @@ jobs:
     image: $(imageName)
     options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
   steps:
+  - template: get-source.yaml
   - script: |
       /tmp/docker exec -t -u 0 ci-container \
       sh -c "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confold" -y install sudo"
@@ -219,6 +267,7 @@ jobs:
     image: $(imageName)
     options: "--name ci-container -v /usr/bin/docker:/tmp/docker:ro"
   steps:
+  - template: get-source.yaml
   - script: |
       /tmp/docker exec -t -u 0 ci-container \
       sh -c "yum install -y sudo"

--- a/build-unix.yaml
+++ b/build-unix.yaml
@@ -1,8 +1,5 @@
 steps:
 - script: |
-    ./get-source.sh
-  displayName: Get libimobiledevice source code
-- script: |
     echo $OSTYPE
   displayName: Determining OSTYPE
 - script: |

--- a/get-source.yaml
+++ b/get-source.yaml
@@ -1,0 +1,34 @@
+# This does not work (properly) when running a container job; see
+# https://github.com/microsoft/azure-pipelines-tasks/issues/12844
+# for more information
+steps:
+- checkout: self
+  path: s
+  target: host
+- checkout: libplist
+  path: s/libplist
+  target: host
+- checkout: libusbmuxd
+  path: s/libusbmuxd
+  target: host
+- checkout: libimobiledevice
+  path: s/libimobiledevice
+  target: host
+- checkout: libideviceactivation
+  path: s/libideviceactivation
+  target: host
+- checkout: ideviceinstaller
+  path: s/ideviceinstaller
+  target: host
+- checkout: libirecovery
+  path: s/libirecovery
+  target: host
+- checkout: idevicerestore
+  path: s/idevicerestore
+  target: host
+- checkout: usbmuxd
+  path: s/usbmuxd
+  target: host
+- checkout: ios-webkit-debug-proxy
+  path: s/ios-webkit-debug-proxy
+  target: host


### PR DESCRIPTION
With this PR, the `get-source.cmd`/`get-source.sh` script is no longer used to check out each of the individual repositories. Instead, the checkout process is now managed by Azure Pipelines.

Because of this:
* There's a guarantee that each leg of the build will use the same source commits. (Previously, there was a possibility that different legs would use different source revisions, if some of the builds were delayed, and a commit would happen in meanwhile).
* The hash of the source commit from each repository will now be displayed in the Source Card in the Azure Pipeline overview. This will improve traceability.